### PR TITLE
Feat: Add support for the new TanStack React Query integration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -177,7 +177,7 @@ function create(info: ts.server.PluginCreateInfo): ts.LanguageService {
       let apiPath = apiMatch[1] || '';
 
       // Look forward to complete the path
-      const forwardMatch = afterCursor.match(/^([\w.]*?)(?:\s*\.\s*(?:useQuery|useMutation|useSubscription|use)|\s|$)/);
+      const forwardMatch = afterCursor.match(/^([\w.]*?)(?:\s*\.\s*(?:useQuery|useMutation|useSubscription|use|queryOptions|mutationOptions)|\s|$)/);
       if (forwardMatch?.[1]) {
         apiPath += forwardMatch[1];
       }


### PR DESCRIPTION
Hi @ebg1223,
This updates the path-matching regex to support the queryOptions pattern now recommended by tRPC and TanStack Query.

### The Problem:
The plugin currently fails to detect tRPC paths when using the modern queryOptions pattern:
```typescript
// Navigation fails on this line
const { data } = useQuery(trpc.myRouter.myProcedure.queryOptions());
```

### The Solution:
I've updated the regex in `src/index.ts` to recognize `.queryOptions` and `mutationOptions` as a valid method call following a procedure path. 
This allows navigation to work correctly for the code above.
This keeps the plugin compatible with the latest tRPC best practices. 

Thanks for the great tool!

